### PR TITLE
feat: do not start service after install on windows

### DIFF
--- a/distributions/axoflow-otel-collector/windows-installer.wxs
+++ b/distributions/axoflow-otel-collector/windows-installer.wxs
@@ -26,8 +26,10 @@
       <Feature Id="Feature" Level="1">
          <ComponentRef Id="ApplicationComponent"/>
          <ComponentRef Id="ConfigComponent"/> 
+         <ComponentRef Id="StartServiceComponent"/>
       </Feature>
 
+      <Property Id="DISABLE_AUTOSTART" Value="0"/>
       <Property Id="COLLECTOR_SVC_ARGS"/>
       <CustomAction
          Id="SetCollectorSvcArgs"
@@ -36,6 +38,8 @@
 
       <InstallExecuteSequence>
          <Custom Action="SetCollectorSvcArgs" Before="InstallFiles">NOT COLLECTOR_SVC_ARGS</Custom>
+      <InstallServices />
+      <StartServices Condition="DISABLE_AUTOSTART&lt;&gt;1" />
       </InstallExecuteSequence>
 
       <Directory Id="TARGETDIR" Name="SourceDir">
@@ -67,9 +71,8 @@
                         Arguments="[COLLECTOR_SVC_ARGS]"
                         Interactive="no"/>
                      <ServiceControl
-                        Id="StartStopRemoveService"
+                        Id="StopRemoveService"
                         Name="{{ .Binary }}"
-                        Start="install"
                         Stop="both"
                         Remove="uninstall"
                         Wait="yes"/>
@@ -82,6 +85,20 @@
                            Name="EventMessageFile"
                            Value="%SystemRoot%\System32\EventCreate.exe"/>
                      </RegistryKey>
+                  </Component>
+                  <Component Id="StartServiceComponent" Guid="*">
+                     <ServiceControl
+                        Id="StartService"
+                        Name="{{ .Binary }}"
+                        Start="install"
+                        Wait="yes"/>
+                  <!-- NOTE:
+                      Windows Installer uses the KeyPath to detect whether a given Component is registered.
+                      ServiceControl type nodes do not have a KeyPath attribute, so we need to supply the RegistryKey manually.
+                  -->
+                     <RegistryKey Root="HKCU" Key="Software\Axoflow">
+                        <RegistryValue Id="StartServiceComponent" Type="string" Name="present" Value="1" KeyPath="yes"/>
+                    </RegistryKey>
                   </Component>
                   <Component Id="ConfigComponent" Guid="*" NeverOverwrite="yes">
                      <File


### PR DESCRIPTION
# Description
Use `DISABLE_AUTOSTART` flag to control whether to autostart service after install.
By default the service starts after install (default value for `DISABLE_AUTOSTART` is 0).

## Proof run
Tested manually, excerpt from the install logs:
```
msiexec.exe /i axo-otel.msi /l*vx install.log /qb DISABLE_AUTOSTART=1
```

```bash
$ cat install_log.txt | grep -in -E 'DISABLE_AUTO|StartServices'
267:MSI (s) (F0:64) [08:41:22:137]: Command Line: DISABLE_AUTOSTART=1 CURRENTDIRECTORY=Z:\ CLIENTUILEVEL=2 CLIENTPROCESSID=2824
289:MSI (s) (F0:64) [08:41:22:137]: PROPERTY CHANGE: Modifying DISABLE_AUTOSTART property. Its current value is '0'. Its new value: '1'.
532:MSI (s) (F0:64) [08:41:22:723]: Skipping action: StartServices (condition is false)
662:Property(S): DISABLE_AUTOSTART = 1
```
