### PR TITLE
feat: keep config file after uninstall on Windows

### DIFF
--- a/distributions/axoflow-otel-collector/windows-installer.wxs
+++ b/distributions/axoflow-otel-collector/windows-installer.wxs
@@ -25,8 +25,10 @@
 
       <Feature Id="Feature" Level="1">
          <ComponentRef Id="ApplicationComponent"/>
-         <ComponentRef Id="ConfigComponent"/> 
          <ComponentRef Id="StartServiceComponent"/>
+      </Feature>
+      <Feature Id="configFeature" Level="1" Absent="disallow">
+         <ComponentRef Id="ConfigComponent"/>
       </Feature>
 
       <Property Id="DISABLE_AUTOSTART" Value="0"/>
@@ -34,7 +36,7 @@
       <CustomAction
          Id="SetCollectorSvcArgs"
          Property="COLLECTOR_SVC_ARGS"
-         Value="--config &quot;[INSTALLDIR]config.yaml&quot;"/>
+         Value="--config &quot;[CommonAppDataFolder]Axoflow\OpenTelemetry Collector\config.yaml&quot;"/>
 
       <InstallExecuteSequence>
          <Custom Action="SetCollectorSvcArgs" Before="InstallFiles">NOT COLLECTOR_SVC_ARGS</Custom>
@@ -100,16 +102,22 @@
                         <RegistryValue Id="StartServiceComponent" Type="string" Name="present" Value="1" KeyPath="yes"/>
                     </RegistryKey>
                   </Component>
-                  <Component Id="ConfigComponent" Guid="*" NeverOverwrite="yes">
-                     <File
-                        Id="config.yaml"
-                        Name="config.yaml"
-                        Source="windows_config.yaml"
-                        KeyPath="yes"/>
-                  </Component>
                </Directory>
             </Directory>
          </Directory>
+           <Directory Id="CommonAppDataFolder">
+                <Directory Id="AxoflowConfigDir" Name="Axoflow">
+                  <Directory Id="AxoflowConfigDirOtelCol" Name="OpenTelemetry Collector">
+                  <Component Id="ConfigComponent" Guid="A4EC99AE-4DBA-4C66-81C5-6434236CC032" Permanent="yes" NeverOverwrite="yes">
+                    <File
+                      Id="ConfigFile"
+                      Name="config.yaml"
+                      Source="windows_config.yaml"
+                      KeyPath="yes"/>
+                  </Component>
+            </Directory>
+          </Directory>
+        </Directory>
       </Directory>
    </Product>
 </Wix>

--- a/distributions/axoflow-otel-collector/windows-installer.wxs
+++ b/distributions/axoflow-otel-collector/windows-installer.wxs
@@ -108,7 +108,7 @@
            <Directory Id="CommonAppDataFolder">
                 <Directory Id="AxoflowConfigDir" Name="Axoflow">
                   <Directory Id="AxoflowConfigDirOtelCol" Name="OpenTelemetry Collector">
-                  <Component Id="ConfigComponent" Guid="A4EC99AE-4DBA-4C66-81C5-6434236CC032" Permanent="yes" NeverOverwrite="yes">
+                  <Component Id="ConfigComponent" Permanent="yes" NeverOverwrite="yes">
                     <File
                       Id="ConfigFile"
                       Name="config.yaml"

--- a/distributions/axoflow-otel-collector/windows-installer.wxs
+++ b/distributions/axoflow-otel-collector/windows-installer.wxs
@@ -59,6 +59,10 @@
                         Id="README.md"
                         Name="README.md"
                         Source="README_windows.md"/>
+                     <File
+                        Id="default_config.yaml"
+                        Name="default_config.yaml"
+                        Source="windows_config.yaml"/>
 
                      <ServiceInstall
                         Id="Service"

--- a/tests/msi/msi_test.go
+++ b/tests/msi/msi_test.go
@@ -91,6 +91,10 @@ func runMsiTest(t *testing.T, test msiTest, msiInstallerPath string) {
 		err := uninstallCmd.Run()
 		t.Logf("Uninstall command: %s", uninstallCmd.SysProcAttr.CmdLine)
 		require.NoError(t, err, "Failed to uninstall the MSI: %v", err)
+
+		// Make sure the config file is kept
+		_, err = os.Stat(getConfigFilePath(t))
+		require.NoError(t, err, "Failed to find config file after uninstall: %v", err)
 	}()
 
 	// Verify the service

--- a/tests/msi/msi_test.go
+++ b/tests/msi/msi_test.go
@@ -156,7 +156,7 @@ func expectedServiceCommand(t *testing.T, serviceName, collectorServiceArgs stri
 	collectorExe := filepath.Join(collectorDir, serviceName) + ".exe"
 
 	if collectorServiceArgs == "" {
-		collectorServiceArgs = "--config " + quotedIfRequired(filepath.Join(collectorDir, "config.yaml"))
+		collectorServiceArgs = "--config " + quotedIfRequired(getConfigFilePath(t))
 	} else {
 		// Remove any quotation added for the msiexec command line
 		collectorServiceArgs = strings.Trim(collectorServiceArgs, "\"")
@@ -164,6 +164,15 @@ func expectedServiceCommand(t *testing.T, serviceName, collectorServiceArgs stri
 	}
 
 	return quotedIfRequired(collectorExe) + " " + collectorServiceArgs
+}
+
+func getConfigFilePath(t *testing.T) string {
+	programDataDir := os.Getenv("PROGRAMDATA")
+	require.NotEmpty(t, programDataDir, "PROGRAMDATA environment variable is not set")
+
+	configFilePath := filepath.Join(programDataDir, "Axoflow", "OpenTelemetry Collector", "config.yaml")
+
+	return configFilePath
 }
 
 func getServiceName(t *testing.T) string {


### PR DESCRIPTION
Manually tested, the file was kept: `C:\ProgramData\Axoflow\OpenTelemetry Collector\config.yaml`

Also extended the E2E MSI test with asserting for keeping the user's configuration.