### PR TITLE
chore: add nopexporter to default configs

### DIFF
--- a/distributions/axoflow-otel-collector/README_linux.md
+++ b/distributions/axoflow-otel-collector/README_linux.md
@@ -23,6 +23,8 @@ exporters:
       insecure: true
 ```
 
+Add `otlp/axorouter` to the `exporters` section of the configuration file.
+
 **NOTE: Don't forget to add the same endpoint in the telemetry section too!**
 
 You can use the [Telemetry controller](https://axoflow.com/reinvent-kubernetes-logging-with-telemetry-controller/) to simplify the creation of collector configuration in Kubernetes environments.

--- a/distributions/axoflow-otel-collector/README_windows.md
+++ b/distributions/axoflow-otel-collector/README_windows.md
@@ -22,6 +22,8 @@ exporters:
     tls:
       insecure: true
 ```
+Add `otlp/axorouter` to the `exporters` section of the configuration file.
+
 
 The default configuration supports the following formats.
 

--- a/distributions/axoflow-otel-collector/linux_config.yaml
+++ b/distributions/axoflow-otel-collector/linux_config.yaml
@@ -11,11 +11,14 @@ exporters:
   debug:
     verbosity: detailed
 
+  nop:
+
 service:
   pipelines:
     logs/system:
       receivers: [filelog/system]
-      exporters: [debug, otlp/axorouter]
+      #exporters: [debug, otlp/axorouter]
+      exporters: [nop]
   telemetry:
     logs:
       level: debug

--- a/distributions/axoflow-otel-collector/linux_config.yaml
+++ b/distributions/axoflow-otel-collector/linux_config.yaml
@@ -8,16 +8,13 @@ exporters:
     tls:
       insecure: true
 
-  debug:
-    verbosity: detailed
-
   nop:
 
 service:
   pipelines:
     logs/system:
       receivers: [filelog/system]
-      #exporters: [debug, otlp/axorouter]
+      #exporters: [otlp/axorouter]
       exporters: [nop]
   telemetry:
     logs:

--- a/distributions/axoflow-otel-collector/manifest.yaml
+++ b/distributions/axoflow-otel-collector/manifest.yaml
@@ -17,6 +17,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.120.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.120.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.120.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.120.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.120.0
   - gomod: github.com/axoflow/fluentforwardexporter v0.120.0-dev1

--- a/distributions/axoflow-otel-collector/windows_config.yaml
+++ b/distributions/axoflow-otel-collector/windows_config.yaml
@@ -67,9 +67,6 @@ exporters:
     tls:
       insecure: true
 
-  debug:
-    verbosity: detailed
-
   nop:
 
 service:

--- a/distributions/axoflow-otel-collector/windows_config.yaml
+++ b/distributions/axoflow-otel-collector/windows_config.yaml
@@ -70,17 +70,22 @@ exporters:
   debug:
     verbosity: detailed
 
+  nop:
+
 service:
   pipelines:
     logs/eventlog:
       receivers: [windowseventlog/application, windowseventlog/system, windowseventlog/security]
       processors: [resource/agent, resourcedetection/system]
-      exporters: [otlp/axorouter]
+      #exporters: [otlp/axorouter]
+      exporters: [nop]
     logs/dns:
       receivers: [filelog/windows_dns_debug_log]
       processors: [resource/agent, resourcedetection/system]
-      exporters: [otlp/axorouter]
+      #exporters: [otlp/axorouter]
+      exporters: [nop]
     logs/dhcp:
       receivers: [filelog/windows_dhcp_server_v4_auditlog, filelog/windows_dhcp_server_v6_auditlog]
       processors: [resource/agent, resourcedetection/system]
-      exporters: [otlp/axorouter]
+      #exporters: [otlp/axorouter]
+      exporters: [nop]


### PR DESCRIPTION
This allows the collector to successfully start without modifying the default configuration.

Manually tested:
```powershell
\axoflow-otel-collector-nop.exe --config .\windows_nop.yaml
2025-04-28T12:13:12.384Z        info    service@v0.120.0/service.go:193 Setting up own telemetry...
2025-04-28T12:13:12.388Z        info    service@v0.120.0/service.go:258 Starting axoflow-otel-collector...      {"Version": "0.120.0", "NumCPU": 2}
2025-04-28T12:13:12.388Z        info    extensions/extensions.go:40     Starting extensions...
....
2025-04-28T12:13:14.263Z        info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "windowseventlog/security", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs"}
2025-04-28T12:13:14.265Z        info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "filelog/windows_dhcp_server_v6_auditlog", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs"}
2025-04-28T12:13:14.265Z        warn    fileconsumer/file.go:49 finding files   {"otelcol.component.id": "filelog/windows_dhcp_server_v6_auditlog", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs", "component": "fileconsumer", "error": "no files match the configured criteria\nfind files with '' pattern: invalid argument"}
2025-04-28T12:13:14.266Z        info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "filelog/windows_dns_debug_log", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs"}
2025-04-28T12:13:14.266Z        warn    fileconsumer/file.go:49 finding files   {"otelcol.component.id": "filelog/windows_dns_debug_log", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs", "component": "fileconsumer", "error": "no files match the configured criteria\nfind files with '' pattern: invalid argument"}
2025-04-28T12:13:14.266Z        info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "windowseventlog/application", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs"}
2025-04-28T12:13:14.267Z        info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "windowseventlog/system", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs"}
2025-04-28T12:13:14.267Z        info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "filelog/windows_dhcp_server_v4_auditlog", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs"}
2025-04-28T12:13:14.267Z        warn    fileconsumer/file.go:49 finding files   {"otelcol.component.id": "filelog/windows_dhcp_server_v4_auditlog", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs", "component": "fileconsumer", "error": "no files match the configured criteria\nfind files with '' pattern: invalid argument"}
2025-04-28T12:13:14.267Z        info    service@v0.120.0/service.go:281 Everything is ready. Begin running and processing data.
```