### PR TITLE
feat: set appropriate build-time version

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -65,6 +65,9 @@ jobs:
           go-version: "~1.24"
           check-latest: true
 
+      - name: Run version update script
+        run: ./scripts/pre-update-version.sh --snapshot
+
       - name: Generate the sources for ${{ inputs.distribution }}
         env:
           DISTRIBUTIONS: ${{ inputs.distribution }}

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -65,6 +65,9 @@ jobs:
           sudo mv llvm-mingw-20250402-ucrt-ubuntu-20.04-x86_64 /opt/llvm-mingw
           sudo ln -s /opt/llvm-mingw/bin/aarch64-w64-mingw32-gcc /usr/local/bin/aarch64-w64-mingw32-gcc
 
+      - name: Run version update script
+        run: ./scripts/pre-update-version.sh "${{ github.ref_name }}"
+
       - name: Generate distribution sources
         run: make generate-sources
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ generate-sources: go ocb
 	@./scripts/build.sh -d "${DISTRIBUTIONS}" -s true -b ${OTELCOL_BUILDER}
 
 goreleaser-verify: goreleaser
+	@./scripts/pre-update-version.sh --snapshot
+	$(MAKE) generate-sources
 	@cd distributions/axoflow-otel-collector && $(GORELEASER) release --snapshot --clean --skip=sign,sbom
 	@cd ../../
+	@./scripts/post-update-version.sh
 
 ensure-goreleaser-up-to-date: generate-goreleaser
 	@git diff -s --exit-code distributions/*/.goreleaser.yaml || (echo "Check failed: The goreleaser templates have changed but the .goreleaser.yamls haven't. Run 'make generate-goreleaser' and update your PR." && exit 1)

--- a/scripts/post-update-version.sh
+++ b/scripts/post-update-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mv "./distributions/axoflow-otel-collector/manifest.yaml.bak" "./distributions/axoflow-otel-collector/manifest.yaml"
+rm -f "./distributions/axoflow-otel-collector/manifest.yaml.bak"
+echo "Restored the original manifest.yaml file."

--- a/scripts/pre-update-version.sh
+++ b/scripts/pre-update-version.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+SNAPSHOT_MODE=false
+for arg in "$@"; do
+  if [ "$arg" == "--snapshot" ]; then
+    SNAPSHOT_MODE=true
+  else
+    VERSION_ARG="$arg"
+  fi
+done
+
+if [ "$SNAPSHOT_MODE" = true ]; then
+    if ! PREVIOUS_TAG=$(git describe --tags --abbrev=0); then
+        echo "Error: Failed to get previous git tag. Are you in a git repository with tags?"
+        exit 1
+    fi
+    PREVIOUS_TAG="${PREVIOUS_TAG#v}"
+    
+    if ! COMMIT_HASH=$(git rev-parse --short=7 HEAD); then
+        echo "Error: Failed to get git commit hash. Are you in a git repository?"
+        exit 1
+    fi
+    
+    NEW_VERSION="${PREVIOUS_TAG}-SNAPSHOT-${COMMIT_HASH}"
+    echo "Creating snapshot version: $NEW_VERSION"
+else
+    if [ -z "$VERSION_ARG" ]; then
+        echo "Usage: $0 <new_version> or $0 --snapshot"
+        echo "Example: $0 0.121.0"
+        exit 1
+    fi
+    NEW_VERSION="$VERSION_ARG"
+fi
+
+CONFIG_FILE="./distributions/axoflow-otel-collector/manifest.yaml"
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: File $CONFIG_FILE not found!"
+    exit 1
+fi
+
+# Use sed with backup to replace the version line
+sed -i.bak "s/^\([ ]*version:[ ]*\)[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*.*/\1$NEW_VERSION/" "$CONFIG_FILE"
+
+if grep -q "version: $NEW_VERSION" "$CONFIG_FILE"; then
+    echo "Version successfully updated to $NEW_VERSION in $CONFIG_FILE"
+else
+    echo "Failed to update version. Most probably the version has already been updated."
+    exit 1
+fi


### PR DESCRIPTION
The runtime version of the agent was derived from `manifest.yaml` which was static on build-time. This PR adds scripts that changes the version number dynamically.