### PR TITLE
feat(default config): add file_storage for filelog receivers

### DIFF
--- a/distributions/axoflow-otel-collector/linux_config.yaml
+++ b/distributions/axoflow-otel-collector/linux_config.yaml
@@ -1,6 +1,7 @@
 receivers:
   filelog/system:
     include: ['/var/log/*.log']
+    storage: file_storage
 
 exporters:
   otlp/axorouter:

--- a/distributions/axoflow-otel-collector/windows_config.yaml
+++ b/distributions/axoflow-otel-collector/windows_config.yaml
@@ -2,12 +2,15 @@ receivers:
   windowseventlog/application:
     channel: application
     raw: true
+    storage: file_storage
   windowseventlog/system:
     channel: system
     raw: true
+    storage: file_storage
   windowseventlog/security:
     channel: security
     raw: true
+    storage: file_storage
 
   filelog/windows_dns_debug_log:
     include: ['']

--- a/distributions/axoflow-otel-collector/windows_config.yaml
+++ b/distributions/axoflow-otel-collector/windows_config.yaml
@@ -11,6 +11,7 @@ receivers:
 
   filelog/windows_dns_debug_log:
     include: ['']
+    storage: file_storage
     resource:
       com.axoflow.vendor: microsoft
       com.axoflow.product: windows-dns
@@ -20,6 +21,7 @@ receivers:
 
   filelog/windows_dhcp_server_v4_auditlog:
     include: ['']
+    storage: file_storage
     start_at: beginning
     resource:
       com.axoflow.vendor: microsoft
@@ -32,6 +34,7 @@ receivers:
 
   filelog/windows_dhcp_server_v6_auditlog:
     include: ['']
+    storage: file_storage
     start_at: beginning
     resource:
       com.axoflow.vendor: microsoft


### PR DESCRIPTION
Fixes #99.

Tested it:
```
2025-09-15T15:46:56.764+0200    info    fileconsumer/file.go:62 Resuming from previously known offset(s). 'start_at' setting is not applicable. {"otelcol.component.id": "filelog/dns-logs", "otelcol.component.kind": "Receiver", "otelcol.signal": "logs", "component": "fileconsumer"}
```