### PR TITLE
chore: bump to v0.156.0

### DIFF
--- a/distributions/axoflow-otel-collector/manifest.yaml
+++ b/distributions/axoflow-otel-collector/manifest.yaml
@@ -45,6 +45,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchlogsreceiver v0.152.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.152.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.152.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.152.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.152.0
 

--- a/distributions/axoflow-otel-collector/manifest.yaml
+++ b/distributions/axoflow-otel-collector/manifest.yaml
@@ -2,76 +2,71 @@ dist:
   module: github.com/axoflow/axoflow-otel-collector-releases
   name: axoflow-otel-collector
   description: Axoflow Distribution for OpenTelemetry Collector
-  version: 0.152.0-axoflow.0
+  version: 0.156.0-axoflow.0
   output_path: ./_build
 
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.152.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.156.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.152.0
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.152.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.152.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.152.0
-  - gomod: github.com/axoflow/fluentforwardexporter v0.152.0-axoflow.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.156.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.156.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.156.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.156.0
+  - gomod: github.com/axoflow/fluentforwardexporter v0.156.0-axoflow.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.152.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.152.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.156.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.156.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.152.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/crowdstrikereceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/etwreceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchlogsreceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.152.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.156.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/crowdstrikereceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/etwreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchlogsreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.156.0
 
 connectors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/bytesconnector v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.152.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/bytesconnector v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.156.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.58.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.58.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.58.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.58.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.58.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.62.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.62.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.62.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.62.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.62.0
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:
   # Axoflow specific replacements for patched/additional components
-  - github.com/open-telemetry/opentelemetry-collector-contrib/connector/bytesconnector =>  github.com/axoflow/opentelemetry-collector-contrib/connector/bytesconnector v0.152.0-axoflow.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/crowdstrikereceiver => github.com/axoflow/opentelemetry-collector-contrib/receiver/crowdstrikereceiver v0.152.0-axoflow.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/etwreceiver => github.com/axoflow/opentelemetry-collector-contrib/receiver/etwreceiver v0.152.0-axoflow.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchlogsreceiver => github.com/axoflow/opentelemetry-collector-contrib/receiver/elasticsearchlogsreceiver v0.152.0-axoflow.0
-  - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/axoflow/opentelemetry-collector-contrib/pkg/stanza v0.152.0-axoflow.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/connector/bytesconnector =>  github.com/axoflow/opentelemetry-collector-contrib/connector/bytesconnector v0.156.0-axoflow.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/crowdstrikereceiver => github.com/axoflow/opentelemetry-collector-contrib/receiver/crowdstrikereceiver v0.156.0-axoflow.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/etwreceiver => github.com/axoflow/opentelemetry-collector-contrib/receiver/etwreceiver v0.156.0-axoflow.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchlogsreceiver => github.com/axoflow/opentelemetry-collector-contrib/receiver/elasticsearchlogsreceiver v0.156.0-axoflow.0
   # Vulnerability patches
-  - github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.311.3
-  # CVE-2026-39827/39828/39829/39830/39831/39832/39833/39834/39835/42508/46595/46597/46598
-  - golang.org/x/crypto => golang.org/x/crypto v0.52.0
-  # CVE-2026-48496
-  - go.opentelemetry.io/ebpf-profiler => go.opentelemetry.io/ebpf-profiler v0.0.202622
+  # (cleared for v0.156.0 — repopulate from the fresh CVE/trivy scan results in a separate `fix: vulnerabilities` commit)


### PR DESCRIPTION
Bumps the Axoflow OTel Collector distribution to **v0.156.0-axoflow.0** (from 0.152.0).

## Changes
- `dist.version` → `0.156.0-axoflow.0`
- All upstream components → `v0.156.0`; confmap providers → `v1.62.0`
- Axoflow fork replaces → `v0.156.0-axoflow.0`: **bytesconnector, crowdstrikereceiver, etwreceiver, elasticsearchlogsreceiver**
- `fluentforwardexporter` → `v0.156.0-axoflow.0`
- **Dropped the `pkg/stanza` replace** — EVTX + env-var-path support upstreamed & released (v0.154.0 / v0.156.0); now upstream `pkg/stanza`. Tracked in axoflow/axoflow#4459.
- **Cleared the previous vulnerability pins** (prometheus, x/crypto, ebpf-profiler) — repopulate from the fresh CVE/trivy scan in a separate `fix: vulnerabilities` commit.
- Merged latest `main` (elasticsearchlogsreceiver + component-validation allowlist).

## Commits
- `feat: add k8sevents receiver` (folded in from #154)
- `chore: bump to v0.156.0`
- `chore: clear previous vulnerability pins for fresh scan`
- merge of `origin/main`

## Notes
- Requires the fork `v0.156.0-axoflow.0` tags live (contrib: bytesconnector/crowdstrikereceiver/etwreceiver/**elasticsearchlogsreceiver**; fluentforwardexporter) for the build to resolve modules.
- Breaking-change scan 0.153→0.156: behavioral default flips in filter/transform `error_mode`, prometheus `add_metric_suffixes`, memory_limiter metric rename, filelog checkpoint encoding. No shipped-component removals/renames.

## Follow-up in this PR
- [x] CVE/vuln workflow green — add back only still-needed pins in a separate `fix: vulnerabilities` commit
- [ ] Human review