### PR TITLE
Fix intermittent private-module fetch failure in CI/release workflows

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -65,7 +65,7 @@ jobs:
           DEPLOY_KEY_PRIVATE_FOR_AXO_ETW: ${{ secrets.DEPLOY_KEY_PRIVATE_FOR_AXO_ETW }}
           DISTRIBUTIONS: ${{ inputs.distribution }}
         run: |
-          ./scripts/prepare-private-modules-gha.sh
+          source ./scripts/prepare-private-modules-gha.sh
           make generate-sources
 
       - name: Run GoReleaser for ${{ inputs.distribution }}

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -71,7 +71,7 @@ jobs:
           DEPLOY_KEY_PRIVATE_FOR_AXO_ETW: ${{ secrets.DEPLOY_KEY_PRIVATE_FOR_AXO_ETW }}
           DISTRIBUTIONS: ${{ inputs.distribution }}
         run: |
-          ./scripts/prepare-private-modules-gha.sh
+          source ./scripts/prepare-private-modules-gha.sh
           make generate-sources
 
       - name: Login to GitHub Package Registry


### PR DESCRIPTION
## Summary

The "Setup private module access and generate sources" step intermittently failed with
`github.com/axoflow/axo-etw: ... fatal: Could not read from remote repository`
(e.g. https://github.com/axoflow/axoflow-otel-collector-releases/actions/runs/29745197227/job/88361328185).

`prepare-private-modules-gha.sh` was executed as a child process, so the `SSH_AUTH_SOCK` it
exports never reached `make generate-sources` running in the same step — its `GITHUB_ENV`
write only takes effect in *subsequent* steps. The job only passed when the setup-go module
cache was hit and `axo-etw` needed no git fetch; on a cold cache (e.g. right after a version
bump changed go.sum) `go mod tidy` had to `git ls-remote` the private repo without an agent
socket and failed. Verified by comparing the failing job (`Cache is not found`) with a passing
job on the same commit (`Cache hit ... setup-go-Linux-x64...`).

Fix: `source` the script instead of executing it, in `base-ci-goreleaser.yaml` and
`base-release.yaml`. Bonus: the step shell runs with `-e`, so a flaky `ssh-keyscan`/`ssh-add`
now fails fast at setup instead of cryptically at `go mod tidy`.

## Test plan

- [x] CI on this PR passes the `check-goreleaser` matrix (exercises the changed step)
- [x] Optionally re-run after invalidating/evicting the setup-go cache to confirm the cold-cache path