### PR TITLE
Adopt upstream collector-releases changes (2026-07 sync)

### DIFF
--- a/.claude/skills/upstream-adopt/SKILL.md
+++ b/.claude/skills/upstream-adopt/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: upstream-adopt
+description: Reviews changes in upstream open-telemetry/opentelemetry-collector-releases against this fork's current state and triages each into adopt / ask / reject, then applies adopted changes on a branch. Use when the user says "sync upstream", "adopt upstream changes", "check what we can pull from upstream", "upstream diff", or "what changed upstream".
+---
+
+# Upstream Adopt
+
+Triage upstream `open-telemetry/opentelemetry-collector-releases` changes against this fork.
+Baseline is always the **current tree** — diff mapped files against `upstream/main`, no sync
+state is stored. We only take what serves this repo (single Axoflow distro, EV signing,
+private modules); everything else is rejected with a recorded reason.
+
+## Step 1 — Fetch and diff
+
+Run `scripts/diff-upstream.sh` to fetch upstream and emit per-file diff stats for all mapped
+paths plus upstream-only files:
+
+```bash
+.claude/skills/upstream-adopt/scripts/diff-upstream.sh
+```
+
+Gotcha it handles: this repo's own release tags collide with upstream's — it always fetches
+with `--no-tags`. Never `git fetch upstream --tags`.
+
+## Step 2 — Load known divergences
+
+Read [references/known-divergences.md](references/known-divergences.md). Entries there are
+permanent, intentional differences — do not re-flag them. Only flag a divergent file when the
+diff contains upstream changes *beyond* what the entry describes.
+
+## Step 3 — Gather context per changed file
+
+For each mapped file with a non-empty diff, get the upstream rationale:
+
+```bash
+version=$(grep -m1 'version:' distributions/axoflow-otel-collector/manifest.yaml | sed 's/.*: *//; s/-axoflow.*//')
+git log --oneline "v${version}..upstream/main" -- <upstream-path>
+```
+
+(If the tag range fails, fall back to `git log --oneline -10 upstream/main -- <path>`.)
+Read the actual diff hunks, not just stats — triage is per logical change, not per file.
+One file can yield multiple findings in different categories.
+
+## Step 4 — Triage
+
+Three categories:
+
+| Category | Criteria |
+|---|---|
+| **adopt** | Bug/security fixes, CI hardening, tooling bumps (goreleaser, ocb, Go, action pins), package-test improvements — anything that applies cleanly to our single-distro, signed-release setup |
+| **ask** | Behavioral changes, structural rewrites of files we customized (goreleaser generation, base workflows, installers), new upstream mechanisms we *could* use (e.g. msi-generator, new scripts/workflows), anything with unclear benefit |
+| **reject** | Reason `not-needed`: other distros (otelcol, k8s, otlp, ebpf-profiler), opampsupervisor, builder, .chloggen/changelog, upstream community files. Reason `techdebt`: would add maintenance burden without benefit to us |
+
+When in doubt between adopt and ask → ask. Never silently adopt a change to a file listed in
+known-divergences.
+
+## Step 5 — Report
+
+Present one table, one line per finding:
+
+```
+category · file (ours) · upstream change summary · reason/benefit
+```
+
+Order: adopt, then ask, then reject. For `ask` items state what upstream gains us and what it
+costs. Wait for the user's verdicts on `ask` items before applying anything.
+
+## Step 6 — Apply
+
+1. Branch: `chore/upstream-sync-<YYYYMMDD>`.
+2. Apply `adopt` items plus approved `ask` items. Port changes by hand into our variants —
+   never blind-copy an upstream file over a customized one; re-apply our deltas.
+3. Validate: `make generate && make check` must pass. Fix or drop a change that breaks it.
+4. If the user permanently rejected something that will keep showing in future diffs, append
+   it to [references/known-divergences.md](references/known-divergences.md) in the same run.
+5. Commit per logical change (atomic), reference upstream commit SHAs in the message body.
+
+## Path mapping
+
+Direct (same path both sides):
+
+- `Makefile`
+- `scripts/{build.sh,generate-goreleaser.sh,validate-components.sh}`
+- `scripts/package-tests/*`
+- `cmd/goreleaser/main.go`, `cmd/goreleaser/internal/{builder,constants,container,helpers,platforms}.go`
+- `.github/workflows/{base-ci-goreleaser,base-package-tests,base-release,ci,msi-tests}.yaml`, `.github/workflows/shellcheck.yml`
+- `tests/docker-tests/default-config.yaml`, `tests/msi/*`
+
+Renamed (upstream → ours; upstream's contrib distro is our template):
+
+- `distributions/otelcol-contrib/<f>` → `distributions/axoflow-otel-collector/<f>` for
+  `Dockerfile`, `Windows.dockerfile`, `*.conf`, `*.service`, `postinstall.sh`, `preinstall.sh`, `preremove.sh`
+- `distributions/otelcol-contrib/config.yaml` → `linux_config.yaml` + `windows_config.yaml`
+- `cmd/goreleaser/internal/distro_contrib.go` → `distro_axoflow_otel_collector.go`
+- `.github/workflows/ci-goreleaser-contrib.yaml` → `ci-goreleaser-axoflow-otel-collector.yaml`
+- `.github/workflows/release-contrib.yaml` → `release-axoflow-otel-collector.yaml`
+
+Upstream-only paths not listed in known-divergences are candidates — triage them (usually
+`ask` for new tooling, `reject/not-needed` for other distros).

--- a/.claude/skills/upstream-adopt/references/known-divergences.md
+++ b/.claude/skills/upstream-adopt/references/known-divergences.md
@@ -1,0 +1,37 @@
+# Known divergences — permanent, do not re-flag
+
+Intentional differences vs upstream. Flag a file below only when its diff shows upstream
+changes *beyond* what the entry describes. Append new entries when the user permanently
+rejects something.
+
+## Structural
+
+- **Single distribution** — we ship only `axoflow-otel-collector`; upstream's otelcol,
+  otelcol-k8s, otelcol-otlp, otelcol-ebpf-profiler distros, `cmd/opampsupervisor`,
+  `cmd/builder`, and their per-distro workflows are permanently not-needed.
+- **`manifest.yaml` is ours** — component list is curated per Axoflow needs, versions bumped
+  by our own pre/post-update-version scripts. Never diff against upstream manifests.
+- **Branding** — `axoflow.ico`, README_linux/README_windows, service/conf file names,
+  `linux_config.yaml`/`windows_config.yaml` split.
+
+## Local-only machinery (no upstream counterpart)
+
+- `scripts/ev-sign.sh`, `signer-image/` — EV code signing.
+- `scripts/pre-update-version.sh`, `scripts/post-update-version.sh` — our version-bump flow.
+- `scripts/prepare-private-modules-gha.{sh,ps1}` — private Go modules in CI.
+- `distributions/axoflow-otel-collector/windows-installer.wxs` — kept in-tree (upstream moved
+  to a `cmd/msi-generator` template).
+- `etw_library_license.txt`, `gofalcon_library_license.txt`.
+
+## Customized shared files
+
+- `scripts/generate-goreleaser.sh` + `cmd/goreleaser/` — reduced to our single distro
+  (`distro_axoflow_otel_collector.go`); upstream multi-distro plumbing intentionally dropped.
+- `Makefile` — single-distro targets, goreleaser-verify wraps our version scripts.
+- `.github/workflows/base-*.yaml` — signing and private-module steps added; upstream
+  distro-matrix logic removed.
+- `scripts/validate-components.sh` — Axoflow component allowlist.
+
+## Permanently rejected upstream changes
+
+(append `- <upstream path or commit> — <reason>` entries here during runs)

--- a/.claude/skills/upstream-adopt/references/known-divergences.md
+++ b/.claude/skills/upstream-adopt/references/known-divergences.md
@@ -57,6 +57,14 @@ rejects something.
   process files.
 - `tests/msi/{go.mod,go.sum,msi_test.go}` — ours is ahead (vuln fixes, Axoflow install-path
   assertions); never sync from upstream.
+- Two-phase `--generate-build-step` build config (9b51357) — our release already splits via
+  goreleaser-pro `--split`/`continue --merge` around EV signing; upstream's extra build stage
+  exists for OBI/Windows-native needs we don't have. Remnants stay commented out.
+- Telemetry prometheus reader defaults (`without_units/type_suffix/scope_info`, 127.0.0.1) —
+  would rename self-metrics on :8888 and break dashboards; ours stays `level: basic`.
+- `tests/golden/` upstream harness (cmd/golden + self-metrics scrape) — replaced by our own
+  log-pipeline golden (filelog → jq canonical diff); upstream's golden tool is metrics-only
+  and our manifest has no prometheus receiver. Never sync tests/golden from upstream.
 
 ## Deferred (re-raise on future runs)
 

--- a/.claude/skills/upstream-adopt/references/known-divergences.md
+++ b/.claude/skills/upstream-adopt/references/known-divergences.md
@@ -35,3 +35,30 @@ rejects something.
 ## Permanently rejected upstream changes
 
 (append `- <upstream path or commit> — <reason>` entries here during runs)
+
+- `cmd/msi-generator/` (fec0c8f) — techdebt: templating our single deeply-customized
+  windows-installer.wxs (branding, config persistence, DISABLE_AUTOSTART) is pure cost.
+- Snapshot version template `-next` (b2a4951 lineage) — our snapshot pipeline
+  (pre-update-version.sh, package-test `*-SNAPSHOT-*` globs) keys on goreleaser's default
+  `-SNAPSHOT-` naming.
+- Nightly release channel (756b394, 5504f17): withNightlyConfig, nightly workflows/inputs,
+  create-issue-on-failure, `package-test.yaml` cron — not-needed.
+- `.github/workflows/update-version.yaml` + `bump-versions.sh` — not-needed: otelbot/multi-
+  manifest release-prep automation; `-axoflow.N` suffix breaks its semver regex.
+- prev-tag / generated release-notes plumbing (`--release-header-tmpl`, release-template.md)
+  — not-needed: no changelog process.
+- OBI/eBPF instrumentation (3ac8983): prepare-obi.sh, fetch-obi action, obi component —
+  not-needed for a log-pipeline distro; revisit only on customer demand.
+- Expanded arch matrix (386/arm/ppc64le/s390x/riscv64/darwin), GOPPC64 — deliberate
+  amd64+arm64-only matrix.
+- docker.io publish, otel self-hosted runners (`otel-windows-latest-8-cores`) — org-specific.
+- chloggen/changelog machinery, `.github/lychee.toml`, `internal/tools/`, root
+  `.goreleaser.yaml`, `docs/release.md`, `distributions/README.md` — upstream community
+  process files.
+- `tests/msi/{go.mod,go.sum,msi_test.go}` — ours is ahead (vuln fixes, Axoflow install-path
+  assertions); never sync from upstream.
+
+## Deferred (re-raise on future runs)
+
+- Windows-native builds/tests (ad76050, 4b8d649): windows-2022 runners, native Win container
+  builds — tangled with our linux wixl+EV-sign MSI flow; user deferred 2026-07-20.

--- a/.claude/skills/upstream-adopt/scripts/diff-upstream.sh
+++ b/.claude/skills/upstream-adopt/scripts/diff-upstream.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UPSTREAM_URL="https://github.com/open-telemetry/opentelemetry-collector-releases.git"
+
+if ! git remote get-url upstream >/dev/null 2>&1; then
+  git remote add upstream "$UPSTREAM_URL"
+fi
+# --no-tags: our release tags collide with upstream's
+git fetch upstream main --no-tags --quiet
+
+echo "## upstream/main: $(git rev-parse --short upstream/main) ($(git log -1 --format=%cs upstream/main))"
+echo
+
+DIRECT_PATHS=(
+  Makefile
+  scripts/build.sh
+  scripts/generate-goreleaser.sh
+  scripts/validate-components.sh
+  scripts/package-tests
+  cmd/goreleaser/main.go
+  cmd/goreleaser/internal/builder.go
+  cmd/goreleaser/internal/constants.go
+  cmd/goreleaser/internal/container.go
+  cmd/goreleaser/internal/helpers.go
+  cmd/goreleaser/internal/platforms.go
+  .github/workflows/base-ci-goreleaser.yaml
+  .github/workflows/base-package-tests.yaml
+  .github/workflows/base-release.yaml
+  .github/workflows/ci.yaml
+  .github/workflows/msi-tests.yaml
+  .github/workflows/shellcheck.yml
+  tests/docker-tests/default-config.yaml
+  tests/msi
+)
+
+echo "## Direct-mapped paths (ours vs upstream/main)"
+for p in "${DIRECT_PATHS[@]}"; do
+  git diff --stat HEAD upstream/main -- "$p" | sed '$d'
+done
+echo
+
+RENAMED_PAIRS=(
+  "distributions/axoflow-otel-collector/Dockerfile:distributions/otelcol-contrib/Dockerfile"
+  "distributions/axoflow-otel-collector/Windows.dockerfile:distributions/otelcol-contrib/Windows.dockerfile"
+  "distributions/axoflow-otel-collector/axoflow-otel-collector.conf:distributions/otelcol-contrib/otelcol-contrib.conf"
+  "distributions/axoflow-otel-collector/axoflow-otel-collector.service:distributions/otelcol-contrib/otelcol-contrib.service"
+  "distributions/axoflow-otel-collector/postinstall.sh:distributions/otelcol-contrib/postinstall.sh"
+  "distributions/axoflow-otel-collector/preinstall.sh:distributions/otelcol-contrib/preinstall.sh"
+  "distributions/axoflow-otel-collector/preremove.sh:distributions/otelcol-contrib/preremove.sh"
+  "distributions/axoflow-otel-collector/linux_config.yaml:distributions/otelcol-contrib/config.yaml"
+  "cmd/goreleaser/internal/distro_axoflow_otel_collector.go:cmd/goreleaser/internal/distro_contrib.go"
+  ".github/workflows/ci-goreleaser-axoflow-otel-collector.yaml:.github/workflows/ci-goreleaser-contrib.yaml"
+  ".github/workflows/release-axoflow-otel-collector.yaml:.github/workflows/release-contrib.yaml"
+)
+
+echo "## Renamed-mapped files (ours vs upstream counterpart, diff line counts)"
+for pair in "${RENAMED_PAIRS[@]}"; do
+  ours="${pair%%:*}"
+  theirs="${pair#*:}"
+  if ! git cat-file -e "upstream/main:${theirs}" 2>/dev/null; then
+    echo "GONE upstream: ${theirs} (ours: ${ours})"
+    continue
+  fi
+  lines=$(git diff "HEAD:${ours}" "upstream/main:${theirs}" | wc -l | tr -d ' ')
+  echo "${lines} ${ours} <- ${theirs}"
+done
+echo
+
+echo "## Upstream-only files (no local counterpart, potential candidates)"
+comm -13 \
+  <(git ls-tree -r --name-only HEAD | sort) \
+  <(git ls-tree -r --name-only upstream/main | sort) |
+  grep -Ev '^(distributions/(otelcol|otelcol-k8s|otelcol-otlp|otelcol-ebpf-profiler|otelcol-contrib)/|cmd/opampsupervisor/|cmd/builder/|cmd/goreleaser/internal/distro_|\.chloggen/|CHANGELOG|CONTRIBUTING|SECURITY|AGENTS\.md|\.github/(CODEOWNERS|pull_request_template|release-template)|\.github/workflows/(ci-goreleaser-|release-|ci-opampsupervisor|ci-builder|nightly-release|fossa|ossf-scorecard|stale))' || true

--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -93,6 +93,29 @@ jobs:
       - name: Print dist folder contents
         run: ls -laR ./distributions/${{ inputs.distribution }}/dist
 
+      - name: Smoke test container image
+        if: ${{ matrix.GOOS == 'linux' && matrix.GOARCH == 'amd64' }}
+        run: |
+          docker run --name ${{ inputs.distribution }} \
+            -d \
+            -v ${PWD}/tests/docker-tests/default-config.yaml:/config.yaml \
+            ghcr.io/axoflow/${{ inputs.distribution }}/${{ inputs.distribution }}:latest-amd64 \
+            --config /config.yaml
+          sleep 10
+          docker logs ${{ inputs.distribution }} &>docker-logs-${{ inputs.distribution }}.log
+          if grep "Everything is ready." docker-logs-${{ inputs.distribution }}.log; then
+            echo "${{ inputs.distribution }} started up correctly"
+          else
+            echo "${{ inputs.distribution }} failed to start"
+            cat docker-logs-${{ inputs.distribution }}.log
+            exit 1
+          fi
+          docker rm -f ${{ inputs.distribution }}
+
+      - name: Run golden test
+        if: ${{ matrix.GOOS == 'linux' && matrix.GOARCH == 'amd64' }}
+        run: make golden-test IMG=ghcr.io/axoflow/${{ inputs.distribution }}/${{ inputs.distribution }}:latest-amd64
+
       - name: Upload linux service packages
         if: ${{ matrix.GOOS == 'linux' && matrix.GOARCH == 'amd64' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases packageName=goreleaser/goreleaser-pro
-  GORELEASER_PRO_VERSION: v2.13.3
+  GORELEASER_PRO_VERSION: v2.17.0
   GONOSUMDB: github.com/axoflow/*
   GOPRIVATE: github.com/axoflow/*
 
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: arm64
 
@@ -48,12 +48,12 @@ jobs:
           sudo apt-get install -y wixl
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "~1.25.0"
+          go-version: "~1.26.0"
           check-latest: true
 
       - name: Run version update script
@@ -71,7 +71,7 @@ jobs:
         run: make generate-sources # inherits SSH_AUTH_SOCK from the previous step via $GITHUB_ENV
 
       - name: Run GoReleaser for ${{ inputs.distribution }}
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_PRO_VERSION }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload linux service packages
         if: ${{ matrix.GOOS == 'linux' && matrix.GOARCH == 'amd64' }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-packages
           path: distributions/${{ inputs.distribution }}/dist/linux_amd64_v1/*
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload MSI packages
         if: ${{ matrix.GOOS == 'windows' && matrix.GOARCH == 'amd64' }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: msi-packages
           path: distributions/${{ inputs.distribution }}/dist/windows_amd64_v1/**/*.msi

--- a/.github/workflows/base-package-tests.yaml
+++ b/.github/workflows/base-package-tests.yaml
@@ -22,10 +22,10 @@ jobs:
         type: ${{ fromJSON(inputs.type) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download built artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: linux-packages
 

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases packageName=goreleaser/goreleaser-pro
-  GORELEASER_PRO_VERSION: v2.13.3
+  GORELEASER_PRO_VERSION: v2.17.0
   GONOSUMDB: github.com/axoflow/*
   GOPRIVATE: github.com/axoflow/*
 
@@ -33,19 +33,19 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - run: ./.github/workflows/scripts/free-disk-space.sh
 
-      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: "v2.6.1"
 
-      - uses: anchore/sbom-action/download-syft@deef08a0db64bfad603422135db61477b16cef56 # v0.22.1
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: arm64
 
@@ -55,11 +55,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wixl
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "~1.25.0"
+          go-version: "~1.26.0"
           check-latest: true
 
       - name: Run version update script
@@ -77,13 +77,13 @@ jobs:
         run: make generate-sources # inherits SSH_AUTH_SOCK from the previous step via $GITHUB_ENV
 
       - name: Login to GitHub Package Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_PRO_VERSION }}
@@ -98,7 +98,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-${{ inputs.distribution }}-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
           path: distributions/${{ inputs.distribution }}/dist/**/*
@@ -119,25 +119,25 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: "v2.6.1"
 
-      - uses: anchore/sbom-action/download-syft@deef08a0db64bfad603422135db61477b16cef56 # v0.22.1
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: arm64
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "~1.25.0"
+          go-version: "~1.26.0"
           check-latest: true
 
       - name: Google auth
@@ -151,20 +151,20 @@ jobs:
         shell: bash
         run: ./signer-image/build-signer.sh "${{ github.ref_name }}"
 
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-${{ inputs.distribution }}-windows-*
           path: distributions/${{ inputs.distribution }}/dist
           merge-multiple: true
 
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-${{ inputs.distribution }}-linux-*
           path: distributions/${{ inputs.distribution }}/dist
           merge-multiple: true
 
       - name: Login to GitHub Package Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -190,7 +190,7 @@ jobs:
         shell: bash
         run: ./scripts/ev-sign.sh "${{ github.ref_name }}"
 
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_PRO_VERSION }}
@@ -203,7 +203,7 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-${{ inputs.distribution }}
           path: distributions/${{ inputs.distribution }}/dist/**/*
@@ -217,14 +217,14 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload Trivy scan results as artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "[${{ github.job }}] Trivy scan results"
           path: trivy-results.sarif
           retention-days: 5
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: trivy-results.sarif
 

--- a/.github/workflows/ci-goreleaser-axoflow-otel-collector.yaml
+++ b/.github/workflows/ci-goreleaser-axoflow-otel-collector.yaml
@@ -3,7 +3,7 @@ name: Continuous Integration - Axoflow Otel Collector - GoReleaser
 on:
   merge_group:
   push:
-    branches: [main]
+    branches: [main, release/*]
     paths:
       - "distributions/axoflow-otel-collector/**"
       - "cmd/**"
@@ -13,7 +13,7 @@ on:
       - "go.mod"
       - "go.sum"
   pull_request:
-    branches: [main]
+    branches: [main, release/*]
     paths:
       - "distributions/axoflow-otel-collector/**"
       - "cmd/**"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,9 @@ name: CI - Collector Binaries
 on:
   merge_group:
   push:
-    branches: [main]
+    branches: [main, release/*]
   pull_request:
-    branches: [main]
+    branches: [main, release/*]
 
 env:
   GONOSUMDB: github.com/axoflow/*
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "~1.25.0"
+          go-version: "~1.26.0"
           check-latest: true
 
       - name: Tidy go.mod files

--- a/.github/workflows/msi-tests.yaml
+++ b/.github/workflows/msi-tests.yaml
@@ -22,10 +22,10 @@ jobs:
         type: ${{ fromJSON(inputs.type) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download built artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: msi-packages
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,9 +2,9 @@ name: Shellcheck lint
 on:
   merge_group: 
   push:
-    branches: [ main ]
+    branches: [main, release/*]
   pull_request:
-    branches: [ main ]
+    branches: [main, release/*]
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         env:

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "~1.25"
+          go-version: "~1.26"
           check-latest: true
 
       - name: Setup private module access
@@ -82,7 +82,7 @@ jobs:
           echo "📄 See the full report in the workflow artifacts." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload scan results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-scan-results
           path: trivy-report.json

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,14 @@ validate-components:
 validate-version-consistency:
 	@./scripts/validate-version-consistency.sh
 
+IMG ?= ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:latest-amd64
+.PHONY: golden-test golden-record
+golden-test:
+	@IMG=${IMG} ./tests/golden/run.sh
+
+golden-record:
+	@IMG=${IMG} ./tests/golden/run.sh --record
+
 .PHONY: ocb
 ocb:
 ifeq (, $(shell command -v ocb 2>/dev/null))

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb
 DISTRIBUTIONS ?= "axoflow-otel-collector"
 
 ci: check build
-check: ensure-goreleaser-up-to-date validate-components
+check: ensure-goreleaser-up-to-date validate-components validate-version-consistency
 
 build: go ocb
 	@./scripts/build.sh -d "${DISTRIBUTIONS}" -b ${OTELCOL_BUILDER}
@@ -35,6 +35,9 @@ ensure-goreleaser-up-to-date: generate-goreleaser
 
 validate-components:
 	@./scripts/validate-components.sh
+
+validate-version-consistency:
+	@./scripts/validate-version-consistency.sh
 
 .PHONY: ocb
 ocb:

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,4 @@ goreleaser:
 REMOTE?=git@github.com:axoflow/axoflow-otel-collector-releases.git
 .PHONY: push-tags
 push-tags:
-	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
-	@echo "Adding tag ${TAG}"
-	@git tag -a ${TAG} -s -m "Version ${TAG}"
-	@echo "Pushing tag ${TAG}"
-	@git push ${REMOTE} ${TAG}
+	@REMOTE=${REMOTE} TAG=${TAG} ./scripts/push-tag.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GO ?= go
 GORELEASER ?= goreleaser
 
+# renovate: datasource=github-releases depName=OCB packageName=open-telemetry/opentelemetry-collector
 OTELCOL_BUILDER_VERSION ?= 0.156.0
 OTELCOL_BUILDER_DIR ?= ${HOME}/bin
 OTELCOL_BUILDER ?= ${OTELCOL_BUILDER_DIR}/ocb

--- a/cmd/goreleaser/internal/builder.go
+++ b/cmd/goreleaser/internal/builder.go
@@ -212,6 +212,9 @@ func (b *distributionBuilder) newNfpms(dist string) []config.NFPM {
 			Overrides: map[string]config.NFPMOverridables{
 				"rpm": {
 					Dependencies: []string{"/bin/sh"},
+					Scripts: config.NFPMScripts{
+						PostInstall: "postinstall-rpm.sh",
+					},
 				},
 			},
 			NFPMOverridables: config.NFPMOverridables{

--- a/cmd/goreleaser/internal/builder.go
+++ b/cmd/goreleaser/internal/builder.go
@@ -330,6 +330,27 @@ func (b *distributionBuilder) withDefaultSnapshot() *distributionBuilder {
 	return b
 }
 
+func (b *distributionBuilder) withVarLibDir(user, group string) *distributionBuilder {
+	b.configFuncs = append(b.configFuncs, func(d *distribution) {
+		for i := range d.Nfpms {
+			d.Nfpms[i].Contents = append(d.Nfpms[i].Contents, config.NFPMContent{
+				Destination: path.Join("/var", "lib", d.Name),
+				Type:        "dir",
+				FileInfo: config.FileInfo{
+					Owner: user,
+					Group: group,
+					// 0750 (octal) = 488 (decimal). The generated YAML emits 488 because
+					// go.yaml.in/yaml/v3 serializes integers as decimal. This is intentional:
+					// decimal 488 is unambiguous across YAML 1.1 and 1.2, whereas octal
+					// notations (0750 / 0o750) are misinterpreted by one or the other.
+					Mode: 0750,
+				},
+			})
+		}
+	})
+	return b
+}
+
 func (b *distributionBuilder) withDefaultMonorepo() *distributionBuilder {
 	b.configFuncs = append(b.configFuncs, func(d *distribution) {
 		b.dist.Monorepo = config.Monorepo{

--- a/cmd/goreleaser/internal/container.go
+++ b/cmd/goreleaser/internal/container.go
@@ -74,7 +74,7 @@ func newContainerImages(dist string, targetOS string, targetArchs []string, opts
 
 // newContainerImageManifests creates container image manifest configurations.
 func newContainerImageManifests(dist, os string, archs []string, opts containerImageOptions) []config.DockerManifest {
-	tags := []string{`{{ .Version }}`}
+	tags := []string{`{{ .Version }}`, "latest"}
 	if os == "windows" {
 		for i, tag := range tags {
 			tags[i] = fmt.Sprintf("%s-%s-%s", tag, os, opts.winVersion)
@@ -97,6 +97,7 @@ func buildDockerImageWithOS(dist, os, arch string, opts containerImageOptions) c
 		imageTemplates = append(
 			imageTemplates,
 			fmt.Sprintf("%s/%s:{{ .Version }}-%s", prefix, imageName(dist, opts), osArch.imageTag()),
+			fmt.Sprintf("%s/%s:latest-%s", prefix, imageName(dist, opts), osArch.imageTag()),
 		)
 	}
 

--- a/cmd/goreleaser/internal/distro_axoflow_otel_collector.go
+++ b/cmd/goreleaser/internal/distro_axoflow_otel_collector.go
@@ -21,5 +21,5 @@ var (
 		d.ContainerImageManifests = slices.Concat(
 			newContainerImageManifests(d.Name, "linux", baseArchs, containerImageOptions{}),
 		)
-	}).withPackagingDefaults().withDefaultConfigIncluded().build()
+	}).withPackagingDefaults().withDefaultConfigIncluded().withVarLibDir("axoflow-otel-collector", "axoflow-otel-collector").build()
 )

--- a/distributions/axoflow-otel-collector/.goreleaser.yaml
+++ b/distributions/axoflow-otel-collector/.goreleaser.yaml
@@ -69,6 +69,12 @@ nfpms:
         dst: /etc/axoflow-otel-collector/etw_library_license.txt
       - src: gofalcon_library_license.txt
         dst: /etc/axoflow-otel-collector/gofalcon_library_license.txt
+      - dst: /var/lib/axoflow-otel-collector
+        type: dir
+        file_info:
+          owner: axoflow-otel-collector
+          group: axoflow-otel-collector
+          mode: 488
     scripts:
       preinstall: preinstall.sh
       postinstall: postinstall.sh

--- a/distributions/axoflow-otel-collector/.goreleaser.yaml
+++ b/distributions/axoflow-otel-collector/.goreleaser.yaml
@@ -129,6 +129,7 @@ dockers:
     dockerfile: Dockerfile
     image_templates:
       - ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:{{ .Version }}-amd64
+      - ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:latest-amd64
     extra_files:
       - linux_config.yaml
       - etw_library_license.txt
@@ -148,6 +149,7 @@ dockers:
     dockerfile: Dockerfile
     image_templates:
       - ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:{{ .Version }}-arm64
+      - ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:latest-arm64
     extra_files:
       - linux_config.yaml
       - etw_library_license.txt
@@ -167,3 +169,7 @@ docker_manifests:
     image_templates:
       - ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:{{ .Version }}-amd64
       - ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:{{ .Version }}-arm64
+  - name_template: ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:latest
+    image_templates:
+      - ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:latest-amd64
+      - ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:latest-arm64

--- a/distributions/axoflow-otel-collector/.goreleaser.yaml
+++ b/distributions/axoflow-otel-collector/.goreleaser.yaml
@@ -83,6 +83,8 @@ nfpms:
       rpm:
         dependencies:
           - /bin/sh
+        scripts:
+          postinstall: postinstall-rpm.sh
     id: axoflow-otel-collector
     ids:
       - axoflow-otel-collector-linux

--- a/distributions/axoflow-otel-collector/postinstall-rpm.sh
+++ b/distributions/axoflow-otel-collector/postinstall-rpm.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+    systemctl try-restart axoflow-otel-collector.service
+fi

--- a/scripts/package-tests/Dockerfile.test.deb
+++ b/scripts/package-tests/Dockerfile.test.deb
@@ -2,7 +2,6 @@
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
 FROM debian:13@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4
 
-
 ENV container=docker \
     DEBIAN_FRONTEND=noninteractive
 

--- a/scripts/package-tests/package-tests.sh
+++ b/scripts/package-tests/package-tests.sh
@@ -72,12 +72,8 @@ add_trap_func podman_logs
 podman build -t "$image_name" -f "$SCRIPT_DIR/Dockerfile.test.$pkg_type" "$SCRIPT_DIR"
 podman rm -fv "$container_name" >/dev/null 2>&1 || true
 
-# Create buffer directory for the collector
-# This is needed to avoid the collector from failing to start due to permission issues
-sudo mkdir -p /var/lib/axoflow-otel-collector/storage && sudo chmod 777 /var/lib/axoflow-otel-collector/storage
-
 # test install
-podman run --name "$container_name" -d -v /var/lib/axoflow-otel-collector/storage:/var/lib/axoflow-otel-collector/storage "$image_name"
+podman run --name "$container_name" -d "$image_name"
 
 # ensure that the system is up and running by checking if systemctl is running
 # TODO(MovieStoreGuy): re-enable when we have a way validate that systemd is fully running

--- a/scripts/package-tests/package-tests.sh
+++ b/scripts/package-tests/package-tests.sh
@@ -81,6 +81,23 @@ podman run --name "$container_name" -d "$image_name"
 
 install_pkg "$container_name" "$PKG_PATH"
 
+if [[ "$pkg_type" == "rpm" ]]; then
+    echo "Checking $SERVICE_NAME service state after install ..."
+    if $container_exec systemctl is-active "$SERVICE_NAME"; then
+        echo "$SERVICE_NAME service running after rpm install" >&2
+        exit 1
+    fi
+    echo "$SERVICE_NAME service correctly not running after rpm install"
+
+    if $container_exec systemctl is-enabled "$SERVICE_NAME"; then
+        echo "$SERVICE_NAME service enabled after rpm install" >&2
+        exit 1
+    fi
+    echo "$SERVICE_NAME service correctly not enabled after rpm install"
+
+    $container_exec systemctl start "$SERVICE_NAME"
+fi
+
 # If we got to this point, we might need to check the logs of the systemd service
 # when it's not properly active. This is added as a trap because the check
 # for service status below will return an error exitcode if the service is 

--- a/scripts/push-tag.sh
+++ b/scripts/push-tag.sh
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+cd "$(dirname "$0")/.."
+
 if ! command -v yq &> /dev/null; then
     echo "This script requires 'yq'. Please install and try again."
     exit 1
@@ -27,9 +29,11 @@ VALIDATE="${VALIDATE:-true}"
 VERSION="${TAG#v}"
 
 if [ "${VALIDATE}" = "true" ]; then
+    checked=0
     for dir in distributions/*/; do
         manifest="${dir}manifest.yaml"
         if [ -f "${manifest}" ]; then
+            checked=$((checked + 1))
             dist_version=$(yq '.dist.version' "${manifest}")
             if [ "${dist_version}" != "${VERSION}" ]; then
                 echo "Version mismatch in ${manifest}: dist.version is set to '${dist_version}', expected '${VERSION}'"
@@ -39,6 +43,10 @@ if [ "${VALIDATE}" = "true" ]; then
             fi
         fi
     done
+    if [ "${checked}" -eq 0 ]; then
+        echo "No manifest found to validate — refusing to tag."
+        exit 1
+    fi
 fi
 
 echo "Adding tag ${TAG}"

--- a/scripts/push-tag.sh
+++ b/scripts/push-tag.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script creates and pushes the specified TAG to REMOTE,
+# validating first that every manifest dist.version matches the tag.
+
+set -euo pipefail
+
+if ! command -v yq &> /dev/null; then
+    echo "This script requires 'yq'. Please install and try again."
+    exit 1
+fi
+
+if [ -z "${TAG:-}" ]; then
+    echo "TAG must be set (e.g. TAG=v0.156.0-axoflow.0)"
+    exit 1
+fi
+if [[ ! "${TAG}" =~ ^v.* ]]; then
+    echo "TAG must start with lowercase 'v' (e.g. v0.156.0-axoflow.0)"
+    exit 1
+fi
+
+REMOTE="${REMOTE:-git@github.com:axoflow/axoflow-otel-collector-releases.git}"
+VALIDATE="${VALIDATE:-true}"
+VERSION="${TAG#v}"
+
+if [ "${VALIDATE}" = "true" ]; then
+    for dir in distributions/*/; do
+        manifest="${dir}manifest.yaml"
+        if [ -f "${manifest}" ]; then
+            dist_version=$(yq '.dist.version' "${manifest}")
+            if [ "${dist_version}" != "${VERSION}" ]; then
+                echo "Version mismatch in ${manifest}: dist.version is set to '${dist_version}', expected '${VERSION}'"
+                echo "Bump the manifest version before tagging."
+                echo "If this version mismatch is expected, please re-run with VALIDATE=false"
+                exit 1
+            fi
+        fi
+    done
+fi
+
+echo "Adding tag ${TAG}"
+git tag -a "${TAG}" -s -m "Version ${TAG}"
+echo "Pushing tag ${TAG}"
+git push "${REMOTE}" "${TAG}"

--- a/scripts/validate-components.sh
+++ b/scripts/validate-components.sh
@@ -113,7 +113,7 @@ while IFS= read -r manifest_file; do
 
   # Compare each manifest component against the valid list
   while IFS= read -r component; do
-    if ! printf '%s\n' "$valid_components" | grep -qxF "$component"; then
+    if ! grep -qxF "$component" <<< "$valid_components"; then
       invalid_components="${invalid_components}\n${component}"
     fi
   done <<< "$manifest_components"

--- a/scripts/validate-version-consistency.sh
+++ b/scripts/validate-version-consistency.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script validates version consistency across manifest files.
+# By default, it only checks that components are internally consistent
+# (all core components have the same version, all contrib components have the same version).
+#
+# Use --check-dist-version to additionally validate that dist.version matches component versions.
+# This stricter check is run automatically by the update-version workflow after bumping versions.
+
+set -euo pipefail
+
+MANIFEST_DIR="distributions"
+CHECK_DIST_VERSION=false
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --check-dist-version) CHECK_DIST_VERSION=true ;;
+        *) echo "Unknown parameter: $1"; echo "Usage: $0 [--check-dist-version]"; exit 1 ;;
+    esac
+    shift
+done
+
+check_dependencies() {
+    if ! command -v yq &> /dev/null; then
+        echo "ERROR: This script requires 'yq'. Please install it and try again."
+        exit 1
+    fi
+}
+
+find_manifest_files() {
+    find "$MANIFEST_DIR" -type f -name "manifest.yaml" | sort
+}
+
+get_dist_version() {
+    local manifest_file="$1"
+    yq -r '.dist.version' "$manifest_file"
+}
+
+# Check if a module should have its version validated
+# Returns 0 (true) if it should be validated, 1 (false) otherwise
+should_validate_module_version() {
+    local module_path="$1"
+
+    # Validate contrib components
+    if [[ "$module_path" == github.com/open-telemetry/opentelemetry-collector-contrib/* ]]; then
+        return 0
+    fi
+
+    # Validate core collector components, EXCEPT providers (they use different versioning like v1.x)
+    if [[ "$module_path" == go.opentelemetry.io/collector/* ]] && \
+       [[ "$module_path" != go.opentelemetry.io/collector/confmap/provider/* ]]; then
+        return 0
+    fi
+
+    # Don't validate:
+    # - Core providers (go.opentelemetry.io/collector/confmap/provider/*) - use v1.x versioning
+    # - eBPF profiler (go.opentelemetry.io/ebpf-profiler) - has its own versioning
+    return 1
+}
+
+# Get the module prefix for grouping (core vs contrib)
+get_module_prefix() {
+    local module_path="$1"
+
+    if [[ "$module_path" == github.com/open-telemetry/opentelemetry-collector-contrib/* ]]; then
+        echo "contrib"
+    elif [[ "$module_path" == go.opentelemetry.io/collector/* ]]; then
+        echo "core"
+    else
+        echo "other"
+    fi
+}
+
+# Extract all components from a manifest that should be version-validated
+get_validatable_components() {
+    local manifest_file="$1"
+
+    yq -r '
+      (
+        .extensions[]?.gomod,
+        .receivers[]?.gomod,
+        .connectors[]?.gomod,
+        .processors[]?.gomod,
+        .exporters[]?.gomod,
+        .providers[]?.gomod
+      )
+    ' "$manifest_file" 2>/dev/null
+}
+
+# Check that all distributions have the same dist.version
+validate_dist_versions_match() {
+    echo "Checking all distributions have the same dist.version..."
+
+    local versions_tmp
+    versions_tmp="$(mktemp)"
+
+    while IFS= read -r manifest_file; do
+        local version
+        version=$(get_dist_version "$manifest_file")
+        echo "$version $manifest_file" >> "$versions_tmp"
+    done < <(find_manifest_files)
+
+    local unique_versions
+    unique_versions=$(awk '{print $1}' "$versions_tmp" | sort -u)
+    local version_count
+    version_count=$(echo "$unique_versions" | wc -l | tr -d ' ')
+
+    if [[ "$version_count" -gt 1 ]]; then
+        echo
+        echo "ERROR: Distributions have different dist.version values:"
+        echo
+        while IFS= read -r line; do
+            local version file
+            version=$(echo "$line" | awk '{print $1}')
+            file=$(echo "$line" | awk '{print $2}')
+            echo "  $file: $version"
+        done < "$versions_tmp"
+        echo
+        echo "All distributions must use the same version."
+        rm -f "$versions_tmp"
+        return 1
+    fi
+
+    echo "  All distributions use version: $unique_versions"
+    rm -f "$versions_tmp"
+    return 0
+}
+
+# Check that all components of the same type (core/contrib) have consistent versions
+validate_component_internal_consistency() {
+    echo
+    echo "Checking internal component version consistency..."
+
+    local has_errors=false
+    local core_versions_tmp
+    local contrib_versions_tmp
+    core_versions_tmp="$(mktemp)"
+    contrib_versions_tmp="$(mktemp)"
+
+    # Collect all versions by type across all manifests
+    while IFS= read -r manifest_file; do
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+
+            local module_path version
+            module_path=$(echo "$line" | awk '{print $1}')
+            version=$(echo "$line" | awk '{print $2}')
+
+            [[ -z "$module_path" || -z "$version" ]] && continue
+
+            if should_validate_module_version "$module_path"; then
+                local prefix
+                prefix=$(get_module_prefix "$module_path")
+
+                if [[ "$prefix" == "core" ]]; then
+                    echo "$version" >> "$core_versions_tmp"
+                elif [[ "$prefix" == "contrib" ]]; then
+                    echo "$version" >> "$contrib_versions_tmp"
+                fi
+            fi
+        done < <(get_validatable_components "$manifest_file")
+    done < <(find_manifest_files)
+
+    # Check core components consistency
+    if [[ -s "$core_versions_tmp" ]]; then
+        local unique_core_versions
+        unique_core_versions=$(sort -u "$core_versions_tmp")
+        local core_version_count
+        core_version_count=$(echo "$unique_core_versions" | wc -l | tr -d ' ')
+
+        if [[ "$core_version_count" -gt 1 ]]; then
+            echo "  ERROR: Core collector components have inconsistent versions:"
+            echo "$unique_core_versions" | while read -r ver; do
+                echo "    $ver"
+            done
+            has_errors=true
+        else
+            echo "  Core components: $unique_core_versions"
+        fi
+    fi
+
+    # Check contrib components consistency
+    if [[ -s "$contrib_versions_tmp" ]]; then
+        local unique_contrib_versions
+        unique_contrib_versions=$(sort -u "$contrib_versions_tmp")
+        local contrib_version_count
+        contrib_version_count=$(echo "$unique_contrib_versions" | wc -l | tr -d ' ')
+
+        if [[ "$contrib_version_count" -gt 1 ]]; then
+            echo "  ERROR: Contrib components have inconsistent versions:"
+            echo "$unique_contrib_versions" | while read -r ver; do
+                echo "    $ver"
+            done
+            has_errors=true
+        else
+            echo "  Contrib components: $unique_contrib_versions"
+        fi
+    fi
+
+    rm -f "$core_versions_tmp" "$contrib_versions_tmp"
+
+    if [[ "$has_errors" == "true" ]]; then
+        echo
+        echo "All core components must use the same version."
+        echo "All contrib components must use the same version."
+        return 1
+    fi
+
+    return 0
+}
+
+# Check that components in a manifest match the distribution version
+validate_components_match_dist_version() {
+    local manifest_file="$1"
+    local dist_version="$2"
+    local expected_version="v${dist_version}"
+    local errors=""
+
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+
+        local module_path version
+        module_path=$(echo "$line" | awk '{print $1}')
+        version=$(echo "$line" | awk '{print $2}')
+
+        [[ -z "$module_path" || -z "$version" ]] && continue
+
+        if should_validate_module_version "$module_path"; then
+            if [[ "$version" != "$expected_version" ]]; then
+                errors+="    $module_path: found $version, expected $expected_version\n"
+            fi
+        fi
+    done < <(get_validatable_components "$manifest_file")
+
+    if [[ -n "$errors" ]]; then
+        echo "  ERROR in $manifest_file:"
+        printf '%b' "$errors"
+        return 1
+    fi
+
+    return 0
+}
+
+# Check all manifests for component version mismatches with dist.version
+validate_all_component_versions_match_dist() {
+    echo
+    echo "Checking components match their distribution version..."
+
+    local has_errors=false
+
+    while IFS= read -r manifest_file; do
+        local dist_version
+        dist_version=$(get_dist_version "$manifest_file")
+
+        if ! validate_components_match_dist_version "$manifest_file" "$dist_version"; then
+            has_errors=true
+        else
+            echo "  $manifest_file: OK"
+        fi
+    done < <(find_manifest_files)
+
+    if [[ "$has_errors" == "true" ]]; then
+        echo
+        echo "Components from opentelemetry-collector-contrib and core collector"
+        echo "must use the same version as the distribution (v{dist.version})."
+        echo
+        echo "Excluded from validation:"
+        echo "  - Core providers (go.opentelemetry.io/collector/confmap/provider/*) - use v1.x versioning"
+        echo "  - eBPF profiler (go.opentelemetry.io/ebpf-profiler) - has its own versioning"
+        return 1
+    fi
+
+    return 0
+}
+
+main() {
+    echo "Validating component version consistency..."
+    echo
+
+    check_dependencies
+
+    local has_errors=false
+
+    # Always check that all distributions have the same dist.version
+    if ! validate_dist_versions_match; then
+        has_errors=true
+    fi
+
+    # Always check internal component consistency
+    if ! validate_component_internal_consistency; then
+        has_errors=true
+    fi
+
+    # Only check dist.version matches components if flag is set
+    if [[ "$CHECK_DIST_VERSION" == "true" ]]; then
+        if ! validate_all_component_versions_match_dist; then
+            has_errors=true
+        fi
+    else
+        echo
+        echo "Skipping dist.version match validation (use --check-dist-version to enable)"
+    fi
+
+    echo
+    if [[ "$has_errors" == "true" ]]; then
+        echo "Validation FAILED. Please fix the version inconsistencies above."
+        exit 1
+    else
+        echo "All version checks passed!"
+    fi
+}
+
+main "$@"

--- a/tests/docker-tests/default-config.yaml
+++ b/tests/docker-tests/default-config.yaml
@@ -6,7 +6,7 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "http://0.0.0.0:4317"
 
 service:
@@ -14,4 +14,4 @@ service:
     metrics:
       receivers: [otlp]
       processors: []
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/tests/golden/.gitignore
+++ b/tests/golden/.gitignore
@@ -1,0 +1,2 @@
+data/output.json
+data/actual.jsonl

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,0 +1,27 @@
+# Golden file test
+
+End-to-end regression test for the log pipeline: the collector container reads
+`data/input.log` via the filelog receiver, zeroes timestamps (transform
+processor, see `config.yaml`), and writes OTLP JSON with the file exporter.
+`run.sh` canonicalizes the emitted log records with `jq` (sorted keys, one
+record per line — independent of batching) and diffs them against
+`data/expected.jsonl`.
+
+Upstream's `cmd/golden` utility is not used: it only implements the OTLP
+metrics service, and this distribution's pipeline is logs.
+
+## Run
+
+```shell
+make golden-test IMG=ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:<version>
+```
+
+## Refresh the expected output
+
+Only needed if the filelog receiver's output shape changes intentionally:
+
+```shell
+make golden-record IMG=ghcr.io/axoflow/axoflow-otel-collector/axoflow-otel-collector:<version>
+```
+
+Commit the updated `data/expected.jsonl` and review the diff.

--- a/tests/golden/config.yaml
+++ b/tests/golden/config.yaml
@@ -1,0 +1,31 @@
+receivers:
+  filelog:
+    include:
+      - /var/data/input.log
+    start_at: beginning
+
+processors:
+  # Zero out timestamps so the golden comparison is fully deterministic
+  transform:
+    log_statements:
+      - context: log
+        statements:
+          - set(time_unix_nano, 0)
+          - set(observed_time_unix_nano, 0)
+
+exporters:
+  debug:
+    verbosity: detailed
+  file:
+    path: /var/data/output.json
+
+service:
+  pipelines:
+    logs:
+      receivers:
+        - filelog
+      processors:
+        - transform
+      exporters:
+        - file
+        - debug

--- a/tests/golden/data/expected.jsonl
+++ b/tests/golden/data/expected.jsonl
@@ -1,0 +1,3 @@
+{"attributes":[{"key":"log.file.name","value":{"stringValue":"input.log"}}],"body":{"stringValue":"hello from axoflow golden test line 1"}}
+{"attributes":[{"key":"log.file.name","value":{"stringValue":"input.log"}}],"body":{"stringValue":"hello from axoflow golden test line 2"}}
+{"attributes":[{"key":"log.file.name","value":{"stringValue":"input.log"}}],"body":{"stringValue":"hello from axoflow golden test line 3"}}

--- a/tests/golden/data/input.log
+++ b/tests/golden/data/input.log
@@ -1,0 +1,3 @@
+hello from axoflow golden test line 1
+hello from axoflow golden test line 2
+hello from axoflow golden test line 3

--- a/tests/golden/docker-compose.yaml
+++ b/tests/golden/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  collector:
+    container_name: golden-collector
+    image: ${IMG}
+    user: ${MY_UID}:${MY_GID}
+    volumes:
+      - ./config.yaml:/etc/config.yaml:ro
+      - ./data:/var/data
+    command:
+      - --config
+      - /etc/config.yaml

--- a/tests/golden/run.sh
+++ b/tests/golden/run.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Golden-file test for the log pipeline: the collector reads a fixed input.log,
+# zeroes timestamps (see config.yaml), and writes OTLP JSON via the file
+# exporter. Records are canonicalized with jq (batching-independent) and diffed
+# against data/expected.jsonl.
+#
+# Usage: IMG=<collector image> ./run.sh [--record]
+#   --record  re-record data/expected.jsonl instead of comparing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if ! command -v jq &> /dev/null; then
+    echo "This script requires 'jq'. Please install and try again."
+    exit 1
+fi
+if [ -z "${IMG:-}" ]; then
+    echo "IMG must be set to the collector image under test"
+    exit 1
+fi
+
+RECORD=false
+[ "${1:-}" = "--record" ] && RECORD=true
+
+EXPECTED_LINES="$(wc -l < data/input.log | tr -d ' ')"
+
+cleanup() {
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        docker compose logs collector 2>/dev/null | tail -40 || true
+    fi
+    MY_UID="$(id -u)" MY_GID="$(id -g)" docker compose down -v >/dev/null 2>&1 || true
+    exit "$status"
+}
+trap cleanup EXIT
+
+rm -f data/output.json
+MY_UID="$(id -u)" MY_GID="$(id -g)" docker compose up -d
+
+echo "Waiting for $EXPECTED_LINES log records ..."
+for _ in $(seq 1 30); do
+    count="$(jq -s '[.[].resourceLogs[].scopeLogs[].logRecords[]] | length' data/output.json 2>/dev/null || echo 0)"
+    [ "$count" -ge "$EXPECTED_LINES" ] && break
+    sleep 2
+done
+if [ "${count:-0}" -lt "$EXPECTED_LINES" ]; then
+    echo "Timed out: got ${count:-0}/$EXPECTED_LINES log records"
+    exit 1
+fi
+
+# Canonical form: one sorted-key JSON log record per line, independent of batching
+jq -cS '.resourceLogs[].scopeLogs[].logRecords[]' data/output.json | sort > data/actual.jsonl
+
+if [ "$RECORD" = "true" ]; then
+    mv data/actual.jsonl data/expected.jsonl
+    echo "Recorded $(wc -l < data/expected.jsonl | tr -d ' ') records to data/expected.jsonl"
+    exit 0
+fi
+
+if diff -u data/expected.jsonl data/actual.jsonl; then
+    echo "Golden test passed"
+    rm -f data/actual.jsonl
+else
+    echo
+    echo "Golden test FAILED: emitted log records differ from data/expected.jsonl"
+    echo "If the change is intentional, refresh with: make golden-record"
+    exit 1
+fi

--- a/tests/golden/run.sh
+++ b/tests/golden/run.sh
@@ -40,9 +40,18 @@ trap cleanup EXIT
 rm -f data/output.json
 MY_UID="$(id -u)" MY_GID="$(id -g)" docker compose up -d
 
+count_records() {
+    # jq may emit a count and still exit non-zero on a partially-written
+    # trailing line; take the last complete value and force it numeric
+    local n
+    n="$(jq -s '[.[].resourceLogs[].scopeLogs[].logRecords[]] | length' data/output.json 2>/dev/null | tail -n1 || true)"
+    [[ "$n" =~ ^[0-9]+$ ]] || n=0
+    echo "$n"
+}
+
 echo "Waiting for $EXPECTED_LINES log records ..."
 for _ in $(seq 1 30); do
-    count="$(jq -s '[.[].resourceLogs[].scopeLogs[].logRecords[]] | length' data/output.json 2>/dev/null || echo 0)"
+    count="$(count_records)"
     [ "$count" -ge "$EXPECTED_LINES" ] && break
     sleep 2
 done


### PR DESCRIPTION
## Summary

First run of the new `upstream-adopt` skill: triaged all drift between this fork and
open-telemetry/opentelemetry-collector-releases (upstream/main @ 9e22d3b), adopted what serves
our single-distro, EV-signed setup, and recorded every rejection with a reason in
`.claude/skills/upstream-adopt/references/known-divergences.md`.

Adopted:
- Pinned-action bumps across all workflows (checkout v7, setup-go v6.5, buildx/qemu v4.2,
  goreleaser-action v7.2.3, cosign v4.1.2, syft v0.24, artifact actions), goreleaser-pro
  v2.17.0, Go ~1.26, CI triggers on `release/*` branches
- OCB 0.143.0 → 0.156.0 (was 13 versions behind the manifest)
- `validate-components.sh` SIGPIPE fix (upstream 5ed0d86); test-image digest bumps; alpine 3.24
- Packages now own `/var/lib/axoflow-otel-collector` (0750, service user, upstream 40c3c2d) —
  replaces the chmod-777 workaround in package-tests
- `validate-version-consistency.sh` wired into `make check`
- **Breaking:** rpm packages no longer auto-enable/start the service on install
  (upstream e770336, RPM packaging convention); deb behavior unchanged
- `push-tags` now validates manifest version before tagging (upstream dffb489)
- Releases publish a floating `latest` container tag — also fixes the Trivy step that already
  scanned `:latest`
- CI smoke test (container starts with the docker-tests config) and a log-pipeline golden test:
  deterministic (timestamps zeroed), batching-independent (jq-canonicalized), refresh via
  `make golden-record`. Upstream's cmd/golden is metrics-only, so this is a log-native redesign.

Rejected (recorded, won't re-flag on future syncs): two-phase `--generate-build-step`
(our `--split`/`continue --merge` already covers it), msi-generator, nightly channel,
renovate.json, update-version bot, OBI/eBPF, arch-matrix expansion, telemetry self-metric
renames, changelog machinery. Deferred: Windows-native builds.

## Test plan

- [x] `make check` green (goreleaser config regenerated + component & version validation)
- [x] `go build ./... && go vet` in cmd/goreleaser
- [x] Golden test recorded and verified twice against released 0.156.0-axoflow.0 image
- [x] `push-tag.sh` guard paths exercised (version mismatch, bad tag, unset TAG, foreign cwd)
- [ ] Reviewer: check the rpm behavior change is acceptable for existing rpm users
- [x] CI: verify smoke + golden jobs pass on this PR