### PR TITLE
Fix intermittent private-module fetch failure via two-step setup

### DIFF
--- a/.github/workflows/base-ci-goreleaser.yaml
+++ b/.github/workflows/base-ci-goreleaser.yaml
@@ -60,13 +60,15 @@ jobs:
         shell: bash
         run: ./scripts/pre-update-version.sh --snapshot
 
-      - name: Setup private module access and generate sources
+      - name: Setup private module access
         env:
           DEPLOY_KEY_PRIVATE_FOR_AXO_ETW: ${{ secrets.DEPLOY_KEY_PRIVATE_FOR_AXO_ETW }}
+        run: ./scripts/prepare-private-modules-gha.sh
+
+      - name: Generate sources for ${{ inputs.distribution }}
+        env:
           DISTRIBUTIONS: ${{ inputs.distribution }}
-        run: |
-          ./scripts/prepare-private-modules-gha.sh
-          make generate-sources
+        run: make generate-sources # inherits SSH_AUTH_SOCK from the previous step via $GITHUB_ENV
 
       - name: Run GoReleaser for ${{ inputs.distribution }}
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -66,13 +66,15 @@ jobs:
         shell: bash
         run: ./scripts/pre-update-version.sh "${{ github.ref_name }}"
 
-      - name: Setup private module access and generate sources
+      - name: Setup private module access
         env:
           DEPLOY_KEY_PRIVATE_FOR_AXO_ETW: ${{ secrets.DEPLOY_KEY_PRIVATE_FOR_AXO_ETW }}
+        run: ./scripts/prepare-private-modules-gha.sh
+
+      - name: Generate sources for ${{ inputs.distribution }}
+        env:
           DISTRIBUTIONS: ${{ inputs.distribution }}
-        run: |
-          ./scripts/prepare-private-modules-gha.sh
-          make generate-sources
+        run: make generate-sources # inherits SSH_AUTH_SOCK from the previous step via $GITHUB_ENV
 
       - name: Login to GitHub Package Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
## Summary

The "Setup private module access and generate sources" step intermittently failed with
`github.com/axoflow/axo-etw: ... fatal: Could not read from remote repository` on a cold
setup-go cache.

Root cause is `77da5a8`, which merged the ssh-agent setup and `make generate-sources` into a
single step **and** dropped the explicit `SSH_AUTH_SOCK` env from the `make` call.
`prepare-private-modules-gha.sh` runs as a child process, so the `SSH_AUTH_SOCK` it exports
never reaches `make` in the same step, and its `$GITHUB_ENV` write only applies to *subsequent*
steps. The job only passed when the module cache was warm and `axo-etw` needed no git fetch; on
a cold cache `go mod tidy` had to `git ls-remote` the private repo with no agent socket and
failed.

## Fix

Split the step back into two (the pre-`77da5a8` shape):

- **Setup private module access** — runs the script; its `$GITHUB_ENV` write exports `SSH_AUTH_SOCK`.
- **Generate sources** — runs `make generate-sources` as a subsequent step, inheriting
  `SSH_AUTH_SOCK` via `$GITHUB_ENV`, the same channel the GoReleaser step already relies on.

This uses the propagation mechanism the script was built around and keeps the script executable
and self-contained, rather than `source`-ing it into the step shell (which would couple the
script's error handling to the step's `set -e` and leave the hardcoded socket path untouched).

Applied to both `base-ci-goreleaser.yaml` and `base-release.yaml`.

## Test plan

- [ ] CI on this PR passes the `check-goreleaser` matrix (exercises the changed step)
- [ ] Re-run after evicting the setup-go cache to confirm the cold-cache path

🤖 Generated with [Claude Code](https://claude.com/claude-code)