### PR TITLE
feat: add text_encoding extension

### DIFF
--- a/distributions/axoflow-otel-collector/manifest.yaml
+++ b/distributions/axoflow-otel-collector/manifest.yaml
@@ -8,6 +8,7 @@ dist:
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.156.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.156.0


### PR DESCRIPTION
feat: add text_encoding extension

Needed so that components handling raw files and byte streams (e.g. the awss3 receiver) can decode plain text payloads instead of only the encodings.